### PR TITLE
fix: download nasm from secure source

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -73,7 +73,7 @@ if [ -d $cache_dir/node/vendor/nasm ]; then
 else
   status "Installing nasm from source"
   NVERSION="2.11"
-  curl http://www.nasm.us/pub/nasm/releasebuilds/$NVERSION/nasm-$NVERSION.tar.gz -s | tar xz
+  curl https://www.nasm.us/pub/nasm/releasebuilds/$NVERSION/nasm-$NVERSION.tar.gz -s | tar xz
   cd nasm-$NVERSION
   ./configure >/dev/null 2>&1 && make >/dev/null 2>&1
 


### PR DESCRIPTION
- Fix compile error by downloading `nasm` from secure source